### PR TITLE
Handle consumer errors

### DIFF
--- a/turtle/src/turtle.rs
+++ b/turtle/src/turtle.rs
@@ -73,7 +73,11 @@ impl<R: BufRead> TurtleParser<R> {
 impl<R: BufRead> TripleParser for TurtleParser<R> {
     type Error = TurtleError;
 
-    fn parse_step(&mut self, on_triple: &mut impl FnMut(Triple) -> ()) -> Result<(), TurtleError> {
+    fn try_parse_step<F, E>(&mut self, on_triple: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Triple) -> Result<(), E>,
+        E: std::error::Error + From<Self::Error>,
+    {
         parse_statement(self, on_triple)
     }
 
@@ -149,10 +153,12 @@ const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
 const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 
-fn parse_statement<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_statement<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     skip_whitespace(&mut parser.read)?;
 
     if parser.read.current() == EOF {
@@ -164,6 +170,7 @@ fn parse_statement<R: BufRead>(
             &parser.iri_parser,
             &mut parser.temp_buf,
         )
+        .map_err(E::from)
     } else if parser.read.starts_with(b"@base") {
         parse_base(
             &mut parser.read,
@@ -171,6 +178,7 @@ fn parse_statement<R: BufRead>(
             &mut parser.object_annotation_buf,
             &mut parser.iri_parser,
         )
+        .map_err(E::from)
     } else if parser.read.starts_with_ignore_ascii_case(b"BASE") {
         parse_sparql_base(
             &mut parser.read,
@@ -178,6 +186,7 @@ fn parse_statement<R: BufRead>(
             &mut parser.object_annotation_buf,
             &mut parser.iri_parser,
         )
+        .map_err(E::from)
     } else if parser.read.starts_with_ignore_ascii_case(b"PREFIX") {
         parse_sparql_prefix(
             &mut parser.read,
@@ -185,6 +194,7 @@ fn parse_statement<R: BufRead>(
             &parser.iri_parser,
             &mut parser.temp_buf,
         )
+        .map_err(E::from)
     } else {
         parse_triples(parser, on_triple)?;
 
@@ -305,10 +315,12 @@ fn parse_triples_or_graph<R: BufRead>(
     Ok(())
 }
 
-fn parse_triples2<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_triples2<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [4g] 	triples2 	::= 	blankNodePropertyList predicateObjectList? '.' | collection predicateObjectList '.'
     match parser.read.current() {
         b'[' if !is_followed_by_space_and_closing_bracket(&parser.read) => {
@@ -329,13 +341,16 @@ fn parse_triples2<R: BufRead>(
     parser.subject_type_stack.pop();
 
     parser.read.check_is_current(b'.')?;
-    parser.read.consume()
+    parser.read.consume()?;
+    Ok(())
 }
 
-fn parse_wrapped_graph<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_wrapped_graph<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [5g] 	wrappedGraph 	::= 	'{' triplesBlock? '}'
     // [6g] 	triplesBlock 	::= 	triples ('.' triplesBlock?)?
     parser.read.check_is_current(b'{')?;
@@ -477,10 +492,12 @@ fn parse_sparql_prefix(
     Ok(())
 }
 
-fn parse_triples<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_triples<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [6] 	triples 	::= 	subject predicateObjectList | blankNodePropertyList predicateObjectList?
     match parser.read.current() {
         b'[' if !is_followed_by_space_and_closing_bracket(&parser.read) => {
@@ -502,10 +519,15 @@ fn parse_triples<R: BufRead>(
     Ok(())
 }
 
-fn parse_predicate_object_list<R: BufRead>(
+fn parse_predicate_object_list<R, F, E>(
     parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+    on_triple: &mut F,
+) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [7] 	predicateObjectList 	::= 	verb objectList (';' (verb objectList)?)*
     loop {
         parse_verb(
@@ -535,10 +557,12 @@ fn parse_predicate_object_list<R: BufRead>(
     }
 }
 
-fn parse_object_list<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_object_list<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [8] 	objectList 	::= 	object (',' object)*
     loop {
         parse_object(parser, on_triple)?;
@@ -578,10 +602,12 @@ fn parse_verb<'a>(
     }
 }
 
-fn parse_subject<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_subject<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     //[10] 	subject 	::= 	iri | BlankNode | collection
     match parser.read.current() {
         b'_' | b'[' => {
@@ -622,10 +648,12 @@ fn parse_predicate<'a>(
     parse_iri(read, buffer, temp_buffer, iri_parser, namespaces)
 }
 
-fn parse_object<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_object<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     //[12] 	object 	::= 	iri | BlankNode | collection | blankNodePropertyList | literal
 
     match parser.read.current() {
@@ -700,11 +728,16 @@ fn parse_object<R: BufRead>(
     Ok(())
 }
 
-fn emit_triple<'a, R: BufRead>(
+fn emit_triple<'a, R, F, E>(
     parser: &'a TurtleParser<R>,
     object_type: TermType,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+    on_triple: &mut F,
+) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     let subject_buf = parser.subject_buf_stack.before_last();
     let subject_type = parser.subject_type_stack[parser.subject_type_stack.len() - 1];
     let predicate_buf = parser.predicate_buf_stack.last();
@@ -718,7 +751,7 @@ fn emit_triple<'a, R: BufRead>(
             to_str(&parser.read, object_buf)?,
             to_str(&parser.read, parser.object_annotation_buf.as_slice())?,
         ),
-    });
+    })?;
     Ok(())
 }
 
@@ -751,10 +784,15 @@ fn parse_literal<'a>(
     }
 }
 
-fn parse_blank_node_property_list<R: BufRead>(
+fn parse_blank_node_property_list<R, F, E>(
     parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+    on_triple: &mut F,
+) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [15] 	collection 	::= 	'(' object* ')'
     parser.read.check_is_current(b'[')?;
     parser.read.consume()?;
@@ -779,10 +817,12 @@ fn parse_blank_node_property_list<R: BufRead>(
     }
 }
 
-fn parse_collection<R: BufRead>(
-    parser: &mut TurtleParser<R>,
-    on_triple: &mut impl FnMut(Triple) -> (),
-) -> Result<(), TurtleError> {
+fn parse_collection<R, F, E>(parser: &mut TurtleParser<R>, on_triple: &mut F) -> Result<(), E>
+where
+    R: BufRead,
+    F: FnMut(Triple) -> Result<(), E>,
+    E: std::error::Error + From<TurtleError>,
+{
     // [15] 	collection 	::= 	'(' object* ')'
     parser.read.check_is_current(b'(')?;
     parser.read.consume()?;
@@ -800,7 +840,7 @@ fn parse_collection<R: BufRead>(
         skip_whitespace(&mut parser.read)?;
 
         if parser.read.current() == EOF {
-            return parser.read.unexpected_char_error();
+            return Ok(parser.read.unexpected_char_error()?);
         } else if parser.read.current() == b')' {
             parser.read.consume()?;
             match root {
@@ -812,7 +852,7 @@ fn parse_collection<R: BufRead>(
                         .into(),
                         predicate: NamedNode { iri: RDF_REST },
                         object: NamedNode { iri: RDF_NIL }.into(),
-                    });
+                    })?;
                     parser.subject_buf_stack.pop();
                     parser.subject_buf_stack.push().extend_from_slice(&id);
                 }
@@ -844,7 +884,7 @@ fn parse_collection<R: BufRead>(
                         id: to_str(&parser.read, &new)?,
                     }
                     .into(),
-                });
+                })?;
                 parser.subject_buf_stack.pop();
             }
             parser.subject_buf_stack.push().extend_from_slice(&new);
@@ -1401,13 +1441,14 @@ impl From<NamedOrBlankNodeType> for TermType {
 fn on_triple_in_graph<'a>(
     on_quad: &'a mut impl FnMut(Quad) -> (),
     graph_name: Option<NamedOrBlankNode<'a>>,
-) -> impl FnMut(Triple) -> () + 'a {
+) -> impl FnMut(Triple) -> Result<(), TurtleError> + 'a {
     move |t: Triple| {
         on_quad(Quad {
             subject: t.subject,
             predicate: t.predicate,
             object: t.object,
             graph_name,
-        })
+        });
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR augments the API of TripleParser and QuadParser with methods `try_parse_step` and `try_parse_all`. These methods differ from `parse_step` and `parse_all` by allowing the passed callback function to return a `Result`.

This is useful because in many situations, the "consumer" of a parser may also fail. For example, an IO error may occur if the consumer stores the triples in a file or on a server. With the current API, one is forced to ignore such errors from the consumer.

Note that `try_parse_X` may also fail because of the parser itself. I made the choice to require that `E` (the error type of the callback function) implement `From<Parser::Error>`, meaning that it is the responsibility of the consumer to "unify" error types.