### PR TITLE
Improved management of line_number and byte_number

### DIFF
--- a/api/src/parser.rs
+++ b/api/src/parser.rs
@@ -180,7 +180,7 @@ pub struct LineBytePosition {
 }
 
 impl LineBytePosition {
-    /// Creates a new position where `line_number` and `byte_number` are both starting from zero
+    /// Creates a new position where `line_number` and `byte_number` are both starting from 1
     pub fn new(line_number: usize, byte_number: usize) -> Self {
         Self {
             line_number,

--- a/turtle/src/error.rs
+++ b/turtle/src/error.rs
@@ -43,8 +43,8 @@ impl fmt::Display for TurtleError {
             write!(
                 f,
                 " on line {} at position {}",
-                position.line_number() + 1,
-                position.byte_number() + 1
+                position.line_number(),
+                position.byte_number(),
             )?;
         }
         Ok(())

--- a/turtle/src/utils.rs
+++ b/turtle/src/utils.rs
@@ -25,10 +25,10 @@ pub trait LookAheadByteRead {
     /// Consumes the many chars and moves to the next one
     fn consume_many(&mut self, count: usize) -> Result<(), TurtleError>;
 
-    /// Returns the line number of the current byte starting at 0
+    /// Returns the line number of the current byte starting at 1
     fn line_number(&self) -> usize;
 
-    /// Returns the byte number of the current byte in the line starting at 0
+    /// Returns the byte number of the current byte in the line starting at 1
     fn byte_number(&self) -> usize;
 
     /// Returns if the current buffer starts with a given byte string. Does not work cross line boundaries
@@ -70,8 +70,8 @@ pub struct LookAheadLineBasedByteReader<R: BufRead> {
     inner: R,
     line: Vec<u8>,
     current: u8,
-    line_number: usize,
-    byte_number: usize,
+    line_offset: usize, // starting at 0
+    byte_offset: usize,
 }
 
 impl<R: BufRead> LookAheadLineBasedByteReader<R> {
@@ -80,12 +80,12 @@ impl<R: BufRead> LookAheadLineBasedByteReader<R> {
             inner,
             line: Vec::default(),
             current: EOF,
-            line_number: 0,
-            byte_number: 0,
+            line_offset: 0,
+            byte_offset: 0,
         };
         // We fill current and next with the appropriate values and we reset properly the line and byte numbers
         this.consume()?;
-        this.line_number = 0;
+        this.line_offset = 0;
         Ok(this)
     }
 }
@@ -96,55 +96,55 @@ impl<R: BufRead> LookAheadByteRead for LookAheadLineBasedByteReader<R> {
     }
 
     fn ahead(&self, count: usize) -> Option<u8> {
-        self.line.get(self.byte_number + count).cloned()
+        self.line.get(self.byte_offset + count).cloned()
     }
 
     fn consume(&mut self) -> Result<(), TurtleError> {
         //TODO: define from consume many?
-        self.byte_number += 1;
-        if self.byte_number >= self.line.len() {
+        self.byte_offset += 1;
+        if self.byte_offset >= self.line.len() {
             self.line.clear();
             self.inner.read_until(b'\n', &mut self.line)?;
-            self.line_number += 1;
-            self.byte_number = 0;
+            self.line_offset += 1;
+            self.byte_offset = 0;
         }
-        self.current = self.line.get(self.byte_number).cloned().unwrap_or(EOF);
+        self.current = self.line.get(self.byte_offset).cloned().unwrap_or(EOF);
         Ok(())
     }
 
     fn consume_many(&mut self, count: usize) -> Result<(), TurtleError> {
-        self.byte_number += count;
-        while self.byte_number >= self.line.len() && !self.line.is_empty() {
-            self.byte_number -= self.line.len();
+        self.byte_offset += count;
+        while self.byte_offset >= self.line.len() && !self.line.is_empty() {
+            self.byte_offset -= self.line.len();
             self.line.clear();
             self.inner.read_until(b'\n', &mut self.line)?;
-            self.line_number += 1;
+            self.line_offset += 1;
         }
-        self.current = self.line.get(self.byte_number).cloned().unwrap_or(EOF);
+        self.current = self.line.get(self.byte_offset).cloned().unwrap_or(EOF);
         Ok(())
     }
 
     fn line_number(&self) -> usize {
-        self.line_number
+        self.line_offset + 1
     }
 
     fn byte_number(&self) -> usize {
-        self.byte_number + 1
+        self.byte_offset + 1
     }
 
     fn starts_with(&self, prefix: &[u8]) -> bool {
-        let end = self.byte_number + prefix.len();
+        let end = self.byte_offset + prefix.len();
         if end < self.line.len() {
-            self.line[self.byte_number..end].eq(prefix)
+            self.line[self.byte_offset..end].eq(prefix)
         } else {
             false
         }
     }
 
     fn starts_with_ignore_ascii_case(&self, prefix: &[u8]) -> bool {
-        let end = self.byte_number + prefix.len();
+        let end = self.byte_offset + prefix.len();
         if end < self.line.len() {
-            self.line[self.byte_number..end].eq_ignore_ascii_case(prefix)
+            self.line[self.byte_offset..end].eq_ignore_ascii_case(prefix)
         } else {
             false
         }

--- a/turtle/src/utils.rs
+++ b/turtle/src/utils.rs
@@ -78,7 +78,8 @@ impl<R: BufRead> LookAheadLineBasedByteReader<R> {
     pub fn new(inner: R) -> Result<Self, TurtleError> {
         let mut this = Self {
             inner,
-            line: Vec::default(),
+            line: vec![10], // emulates an empty line,
+            // so that the first call to consume() does not stop as if EOF
             current: EOF,
             line_offset: 0,
             byte_offset: 0,
@@ -99,17 +100,9 @@ impl<R: BufRead> LookAheadByteRead for LookAheadLineBasedByteReader<R> {
         self.line.get(self.byte_offset + count).cloned()
     }
 
+    #[inline]
     fn consume(&mut self) -> Result<(), TurtleError> {
-        //TODO: define from consume many?
-        self.byte_offset += 1;
-        if self.byte_offset >= self.line.len() {
-            self.line.clear();
-            self.inner.read_until(b'\n', &mut self.line)?;
-            self.line_offset += 1;
-            self.byte_offset = 0;
-        }
-        self.current = self.line.get(self.byte_offset).cloned().unwrap_or(EOF);
-        Ok(())
+        self.consume_many(1)
     }
 
     fn consume_many(&mut self, count: usize) -> Result<(), TurtleError> {


### PR DESCRIPTION
This addresses issue #11. `ParseError` now stores line_number and byte_number starting at 1, which makes them more suitable for error reporting.

`LookAheadLineBasedByteReader` internally uses 0-based indexes, which were renamed to `line_offset` and `byte_offset` to prevent confusion.

I also removed some code redundancy in `LookAheadLineBasedByteReader` (there was a comment suggesting to do so).